### PR TITLE
Fix example page for non-visible state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,39 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Demo: can-autoplay</title>
+  <meta charset="UTF-8">
+  <title>Demo: can-autoplay</title>
 </head>
 <body>
 <h1>can-autoplay</h1>
 <ul>
-    <li class='video'>video</li>
-    <li class='videoMuted'>video muted</li>
-    <li class='audio'>audio</li>
-    <li class='audioMuted'>audio muted</li>
+  <li class='video'>video</li>
+  <li class='videoMuted'>video muted</li>
+  <li class='audio'>audio</li>
+  <li class='audioMuted'>audio muted</li>
 </ul>
 
 <script src="./build/can-autoplay.js"></script>
 <script>
   const $ = document.querySelector.bind(document)
-  let tests = [
-    {selector: '.video', method: 'video', params: null},
-    {selector: '.videoMuted', method: 'video', params: {muted: true}},
-    {selector: '.audio', method: 'audio', params: null},
-    {selector: '.audioMuted', method: 'audio', params: {muted: true}}
-  ]
 
-  tests.reduce((testSequence, test) => {
-    return testSequence
-      .then(() => {
-        return canAutoplay[test.method](test.params).then(({result, error}) => {
-          $(test.selector).innerText += (result === true) ? ' ✅' : (' 🚫 ' + `( Error "${error.name}": ${error.message}) `)
+  function initTests() {
+    let tests = [
+      {selector: '.video', method: 'video', params: null},
+      {selector: '.videoMuted', method: 'video', params: {muted: true}},
+      {selector: '.audio', method: 'audio', params: null},
+      {selector: '.audioMuted', method: 'audio', params: {muted: true}}
+    ]
+
+    tests.reduce((testSequence, test) => {
+      return testSequence
+        .then(() => {
+          return canAutoplay[test.method](test.params).then(({result, error}) => {
+            $(test.selector).innerText += (result === true) ? ' ✅' : (' 🚫 ' + `( Error "${error.name}": ${error.message}) `)
+          })
         })
-      })
-      .then(() => {
-        return new Promise(resolve => setTimeout(resolve, 1000))
-      })
-  }, Promise.resolve());
+        .then(() => {
+          return new Promise(resolve => setTimeout(resolve, 1000))
+        })
+    }, Promise.resolve())
+  }
+
+  if (document.visibilityState === 'visible') {
+    initTests()
+  } else {
+    document.addEventListener('visibilitychange', function handleVisibilityChange() {
+      if (document.visibilityState !== 'visible') return true
+
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      initTests()
+    })
+  }
 
 </script>
 </body>


### PR DESCRIPTION
Fixes a bug when a page is started in a non-visible state.

### Reproducing the bug
- Go to https://github.com/video-dev/can-autoplay
- Open demo page in a new tab (on macOS, hold cmd while clicking)
- On Firefox it will fail video tests since the page is not visible