### PR TITLE
Add Inline Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - TBD
+
+- Added option `inline` to check auto-play for inline playback
+
 ## [2.1.1] - 2018-02-02
 
 - Added notes about media files used in the project

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Build files are available in the `build/` directory. Bundlers will choose get th
 
 Parameters:
 
+- options.inline `<Boolean>`, check if auto-play is possible for an inline playback, default value is `false`
 - options.muted `<Boolean>`, check if auto-play is possible for a muted content
 - options.timeout `<Number>`, timeout for a check, default value is `250` ms
 
@@ -62,6 +63,7 @@ canAutoplay.audio().then(({result}) => {
 
 Parameters:
 
+- options.inline `<Boolean>`, check if auto-play is possible for an inline playback, default value is `false`
 - options.muted `<Boolean>`, check if auto-play is possible for a muted content
 - options.timeout `<Number>`, timeout for a check, default value is `250` ms
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 <ul>
     <li class='video'>video</li>
     <li class='videoMuted'>video muted</li>
+    <li class='videoInline'>video inline</li>
+    <li class='videoInlineMuted'>video inline muted</li>
     <li class='audio'>audio</li>
     <li class='audioMuted'>audio muted</li>
 </ul>
@@ -19,6 +21,8 @@
   let tests = [
     {selector: '.video', method: 'video', params: null},
     {selector: '.videoMuted', method: 'video', params: {muted: true}},
+    {selector: '.videoInline', method: 'video', params: {inline: true}},
+    {selector: '.videoInlineMuted', method: 'video', params: {inline: true, muted: true}},
     {selector: '.audio', method: 'audio', params: null},
     {selector: '.audioMuted', method: 'audio', params: {muted: true}}
   ]

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,16 +10,25 @@ function audio (options) {
 }
 
 function setupDefaultValues (options) {
-  return Object.assign({muted: false, timeout: 250}, options)
+  return Object.assign({muted: false, timeout: 250, inline: false}, options)
 }
 
-function startPlayback ({muted, timeout}, elementCallback) {
+function startPlayback ({muted, timeout, inline}, elementCallback) {
   let {element, source} = elementCallback()
   let playResult
   let timeoutId
   let sendOutput
 
   element.muted = muted
+  if (muted === true) {
+      element.setAttribute('muted', 'muted')
+  }
+  // indicates that the video is to be played "inline",
+  // that is within the element's playback area.
+  if (inline === true) {
+      element.setAttribute('playsinline', 'playsinline')
+  }
+
   element.src = source
 
   return new Promise(resolve => {


### PR DESCRIPTION
- Adds ability to provide `inline` option, to check if auto-play is possible with inline playback

Change has a value only for iOS environment.

Notes:

- resolve #11 